### PR TITLE
Feat: REST API 맛집 조회

### DIFF
--- a/.idea/GIS-recommendation.iml
+++ b/.idea/GIS-recommendation.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="17" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/GIS-recommendation.iml" filepath="$PROJECT_DIR$/.idea/GIS-recommendation.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ChangeListManager">
+    <list default="true" id="bd88bb5d-c870-4b65-818b-82e7563fb18b" name="변경" comment="">
+      <change afterPath="$PROJECT_DIR$/.idea/GIS-recommendation.iml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/misc.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/modules.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/vcs.xml" afterDir="false" />
+      <change afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
+  </component>
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="MarkdownSettingsMigration">
+    <option name="stateVersion" value="1" />
+  </component>
+  <component name="ProjectColorInfo">{
+  &quot;associatedIndex&quot;: 0
+}</component>
+  <component name="ProjectId" id="2XXX2MhKOX1qGLFAfoRyB4akSKd" />
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;RunOnceActivity.OpenProjectViewOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;WebServerToolWindowFactoryState&quot;: &quot;false&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;main&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/wanted-pre-onboarding/preonboarding/GIS-recommendation/demo&quot;,
+    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;
+  }
+}</component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="애플리케이션 수준" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="디폴트 작업">
+      <changelist id="bd88bb5d-c870-4b65-818b-82e7563fb18b" name="변경" comment="" />
+      <created>1698776190367</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1698776190367</updated>
+      <workItem from="1698776191353" duration="74000" />
+      <workItem from="1698776446644" duration="53000" />
+    </task>
+    <servers />
+  </component>
+  <component name="TypeScriptGeneratedFilesManager">
+    <option name="version" value="3" />
+  </component>
+</project>

--- a/demo/.gitignore
+++ b/demo/.gitignore
@@ -72,3 +72,4 @@ Temporary Items
 # End of https://www.toptal.com/developers/gitignore/api/macos
 
 *.yml
+*.csv

--- a/demo/src/main/java/com/wanted/demo/area/controller/AreaController.java
+++ b/demo/src/main/java/com/wanted/demo/area/controller/AreaController.java
@@ -1,20 +1,35 @@
 package com.wanted.demo.area.controller;
 
+import com.wanted.demo.area.dto.AreaDTO;
 import com.wanted.demo.area.service.AreaService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Slf4j
 @RequiredArgsConstructor
 @RestController
+@RequestMapping("/api/area")
 public class AreaController {
 
     private final AreaService areaService;
 
-    @PostMapping("/api/area/info-data")
+    @PostMapping("/info-data")
     public void saveAreaInfoCsv() {
         areaService.saveAreaInfoCsvToDb();
+    }
+
+    @GetMapping("/list")
+    public List<AreaDTO> getAreaList() {
+        return areaService.getAreaList();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<AreaDTO> getAreaDetails(@PathVariable Long id) {
+        AreaDTO areaDetails = areaService.getAreaDetails(id);
+        return ResponseEntity.ok(areaDetails);
     }
 }

--- a/demo/src/main/java/com/wanted/demo/area/dto/AreaDTO.java
+++ b/demo/src/main/java/com/wanted/demo/area/dto/AreaDTO.java
@@ -1,0 +1,27 @@
+package com.wanted.demo.area.dto;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AreaDTO {
+    private Long id;
+    private String doSi;
+    private String sgg;
+    private Double longitude;
+    private Double latitude;
+
+    public AreaDTO(Long id, String doSi, String sgg) {
+        this.id = id;
+        this.doSi = doSi;
+        this.sgg = sgg;
+    }
+    public AreaDTO(Long id, String doSi, String sgg, Double longitude, Double latitude) {
+        this.id = id;
+        this.doSi = doSi;
+        this.sgg = sgg;
+        this.longitude = longitude;
+        this.latitude = latitude;
+    }
+}

--- a/demo/src/main/java/com/wanted/demo/area/entity/Area.java
+++ b/demo/src/main/java/com/wanted/demo/area/entity/Area.java
@@ -1,10 +1,12 @@
 package com.wanted.demo.area.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 @Entity
+@Getter
 public class Area {
 
     @Id

--- a/demo/src/main/java/com/wanted/demo/area/service/AreaService.java
+++ b/demo/src/main/java/com/wanted/demo/area/service/AreaService.java
@@ -1,7 +1,9 @@
 package com.wanted.demo.area.service;
 
+import com.wanted.demo.area.dto.AreaDTO;
 import com.wanted.demo.area.entity.Area;
 import com.wanted.demo.area.repository.AreaRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,6 +13,9 @@ import org.springframework.transaction.annotation.Transactional;
 import java.io.BufferedReader;
 import java.io.FileReader;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -37,6 +42,38 @@ public class AreaService {
             }
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+    }
+
+    public List<AreaDTO> getAreaList() {
+        List<Area> areas = areaRepository.findAll();
+        List<AreaDTO> areaList = new ArrayList<>();
+
+        for (Area area : areas) {
+            AreaDTO areaDTO = new AreaDTO(
+                    area.getId(),
+                    area.getDoSi(),
+                    area.getSgg()
+            );
+            areaList.add(areaDTO);
+        }
+        return areaList;
+    }
+
+    public AreaDTO getAreaDetails(Long id) {
+        Optional<Area> areaOptional = areaRepository.findById(id);
+
+        if (areaOptional.isPresent()) {
+            Area area = areaOptional.get();
+            return new AreaDTO(
+                    area.getId(),
+                    area.getDoSi(),
+                    area.getSgg(),
+                    area.getLongitude(),
+                    area.getLatitude()
+            );
+        } else {
+            throw new EntityNotFoundException("지역id가 존재하지 않습니다. id : " + id);
         }
     }
 }

--- a/demo/src/main/java/com/wanted/demo/store/controller/StoreController.java
+++ b/demo/src/main/java/com/wanted/demo/store/controller/StoreController.java
@@ -21,7 +21,11 @@ public class StoreController {
 
     @GetMapping("/storesInRange")
     @ResponseBody
-    public List<StoreListDTO> getStoresInRange( @RequestParam("lat") double lat, @RequestParam("lon") double lon, @RequestParam("range") double range ) {
-        return storeService.findStoresInRange(lat,lon,range);
+    public List<StoreListDTO> getStoresInRange(
+            @RequestParam("lat") double lat,
+            @RequestParam("lon") double lon,
+            @RequestParam("range") double range,
+            @RequestParam(name="sort", required = false, defaultValue = "distance") String sort) {
+        return storeService.findStoresInRange(lat,lon,range,sort);
     }
 }

--- a/demo/src/main/java/com/wanted/demo/store/controller/StoreController.java
+++ b/demo/src/main/java/com/wanted/demo/store/controller/StoreController.java
@@ -21,7 +21,7 @@ public class StoreController {
 
     @GetMapping("/storesInRange")
     @ResponseBody
-    public List<StoreListDTO> getStoresInRange(@RequestParam("lat") double lat, @RequestParam("lon") double lon, @RequestParam("range") double range) {
+    public List<StoreListDTO> getStoresInRange( @RequestParam("lat") double lat, @RequestParam("lon") double lon, @RequestParam("range") double range ) {
         return storeService.findStoresInRange(lat,lon,range);
     }
 }

--- a/demo/src/main/java/com/wanted/demo/store/controller/StoreController.java
+++ b/demo/src/main/java/com/wanted/demo/store/controller/StoreController.java
@@ -1,16 +1,16 @@
 package com.wanted.demo.store.controller;
 
+import com.wanted.demo.store.dto.StoreDetailDTO;
 import com.wanted.demo.store.dto.StoreListDTO;
 import com.wanted.demo.store.service.StoreService;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
+@RequestMapping("/api/store")
 public class StoreController {
     private final StoreService storeService;
 
@@ -19,7 +19,7 @@ public class StoreController {
         this.storeService = storeService;
     }
 
-    @GetMapping("/storesInRange")
+    @GetMapping("/recom")
     @ResponseBody
     public List<StoreListDTO> getStoresInRange(
             @RequestParam("lat") double lat,
@@ -27,5 +27,11 @@ public class StoreController {
             @RequestParam("range") double range,
             @RequestParam(name="sort", required = false, defaultValue = "distance") String sort) {
         return storeService.findStoresInRange(lat,lon,range,sort);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<StoreDetailDTO> getStoreDetails(@PathVariable Long id) {
+        StoreDetailDTO storeDetailDTO = storeService.getStoreDetails(id);
+        return ResponseEntity.ok(storeDetailDTO);
     }
 }

--- a/demo/src/main/java/com/wanted/demo/store/controller/StoreController.java
+++ b/demo/src/main/java/com/wanted/demo/store/controller/StoreController.java
@@ -1,0 +1,27 @@
+package com.wanted.demo.store.controller;
+
+import com.wanted.demo.store.dto.StoreListDTO;
+import com.wanted.demo.store.service.StoreService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+public class StoreController {
+    private final StoreService storeService;
+
+    @Autowired
+    public StoreController(StoreService storeService) {
+        this.storeService = storeService;
+    }
+
+    @GetMapping("/storesInRange")
+    @ResponseBody
+    public List<StoreListDTO> getStoresInRange(@RequestParam("lat") double lat, @RequestParam("lon") double lon, @RequestParam("range") double range) {
+        return storeService.findStoresInRange(lat,lon,range);
+    }
+}

--- a/demo/src/main/java/com/wanted/demo/store/dto/ReviewDTO.java
+++ b/demo/src/main/java/com/wanted/demo/store/dto/ReviewDTO.java
@@ -1,0 +1,18 @@
+package com.wanted.demo.store.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ReviewDTO {
+    private Long id;
+    private int rating;
+    private String evaluation;
+    private String userName;
+
+    public ReviewDTO(Long id, int rating, String evaluation, String userName) {
+        this.id = id;
+        this.rating = rating;
+        this.evaluation = evaluation;
+        this.userName = userName;
+    }
+}

--- a/demo/src/main/java/com/wanted/demo/store/dto/StoreDetailDTO.java
+++ b/demo/src/main/java/com/wanted/demo/store/dto/StoreDetailDTO.java
@@ -1,0 +1,42 @@
+package com.wanted.demo.store.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@AllArgsConstructor
+public class StoreDetailDTO {
+    private Long id;
+    private String storeId;
+    private String bizplcNm;
+    private LocalDate licensgDe;
+    private String bsnStateNm;
+    private String clsbizDe;
+    private Double locplcAr;
+    private String gradFacltDivNm;
+    private Integer maleEnflpsnCnt;
+    private Integer yy;
+    private String multiUseBizestblYn;
+    private String gradDivNm;
+    private Double totFacltScale;
+    private Integer femaleEnflpsnCnt;
+    private String bsnsiteCircumfrDivNm;
+    private String sanittnIndutypeNm;
+    private String sanittnBizcondNm;
+    private Double totEmplyCnt;
+    private String refineRoadnmAddr;
+    private String refineLotnoAddr;
+    private String refineZipCd;
+    private Double refineWgs84Lat;
+    private Double refineWgs84Logt;
+    private Double rating;
+    private List<ReviewDTO> reviews;
+}

--- a/demo/src/main/java/com/wanted/demo/store/dto/StoreListDTO.java
+++ b/demo/src/main/java/com/wanted/demo/store/dto/StoreListDTO.java
@@ -1,0 +1,26 @@
+package com.wanted.demo.store.dto;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class StoreListDTO {
+    private Long id;
+    private String storeId;
+    private String bizplcNm;
+    private Double rating;
+    private Double refineWgs84Lat;
+    private Double refineWgs84Logt;
+    private Double distance;
+
+    public StoreListDTO(Long id, String storeId, String bizplcNm, Double rating, Double refineWgs84Lat, Double refineWgs84Logt, Double distance) {
+        this.id = id;
+        this.storeId = storeId;
+        this.bizplcNm = bizplcNm;
+        this.rating = rating;
+        this.refineWgs84Lat = refineWgs84Lat;
+        this.refineWgs84Logt = refineWgs84Logt;
+        this.distance = distance;
+    }
+}

--- a/demo/src/main/java/com/wanted/demo/store/dto/StoreListDTO.java
+++ b/demo/src/main/java/com/wanted/demo/store/dto/StoreListDTO.java
@@ -2,7 +2,9 @@ package com.wanted.demo.store.dto;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
 
+@Getter
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class StoreListDTO {

--- a/demo/src/main/java/com/wanted/demo/store/service/StoreService.java
+++ b/demo/src/main/java/com/wanted/demo/store/service/StoreService.java
@@ -1,0 +1,63 @@
+package com.wanted.demo.store.service;
+
+import com.wanted.demo.store.dto.StoreListDTO;
+import com.wanted.demo.store.entity.Store;
+import com.wanted.demo.store.repository.StoreRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class StoreService {
+    private final StoreRepository storeRepository;
+
+    @Autowired
+    public StoreService(StoreRepository storeRepository) {
+        this.storeRepository = storeRepository;
+    }
+
+    public List<StoreListDTO> findStoresInRange(double lat, double lon, double range) {
+        List<Store> stores = storeRepository.findAll();
+
+        List<StoreListDTO> storesInRange = new ArrayList<>();
+
+        for (Store store : stores) {
+            double storeLat = store.getRefineWgs84Lat();
+            double storeLon = store.getRefineWgs84Logt();
+
+            double distance = latLonToKm(storeLat, storeLon, lat, lon);
+
+            if (distance <= range) {
+                StoreListDTO storeListDTO = new StoreListDTO(
+                        store.getId(),
+                        store.getStoreId(),
+                        store.getBizplcNm(),
+                        store.getRating(),
+                        storeLat,
+                        storeLon,
+                        distance
+                );
+                storesInRange.add(storeListDTO);
+            }
+        }
+        return storesInRange;
+    }
+
+    private double latLonToKm(double storeLat, double storeLon, double lat2, double lon2) {
+        double radius = 6371; //km
+
+        double dLat = Math.toRadians(lat2 - storeLat);
+        double dLon = Math.toRadians(lon2 - storeLon);
+
+        storeLat = Math.toRadians(storeLat);
+        lat2 = Math.toRadians(lat2);
+
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+                Math.sin(dLon / 2) * Math.sin(dLon / 2) * Math.cos(storeLat) * Math.cos(lat2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+        return radius * c;
+    }
+}

--- a/demo/src/main/java/com/wanted/demo/store/service/StoreService.java
+++ b/demo/src/main/java/com/wanted/demo/store/service/StoreService.java
@@ -1,16 +1,25 @@
 package com.wanted.demo.store.service;
 
+import com.wanted.demo.store.dto.ReviewDTO;
+import com.wanted.demo.store.dto.StoreDetailDTO;
 import com.wanted.demo.store.dto.StoreListDTO;
+import com.wanted.demo.store.entity.Review;
 import com.wanted.demo.store.entity.Store;
 import com.wanted.demo.store.repository.StoreRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 @Service
+@Slf4j
 public class StoreService {
     private final StoreRepository storeRepository;
 
@@ -73,4 +82,54 @@ public class StoreService {
 
         return radius * c;
     }
+
+    public StoreDetailDTO getStoreDetails(Long id) {
+        Optional<Store> storeOptional = storeRepository.findById(id);
+
+        if (storeOptional.isPresent()) {
+            Store store = storeOptional.get();
+            List<ReviewDTO> reviewDTOs = new ArrayList<>();
+
+            for(Review review : store.getReviews()) {
+                ReviewDTO reviewDTO = new ReviewDTO(
+                        review.getId(),
+                        review.getRating(),
+                        review.getEvaluation(),
+                        review.getUser().getUsername()
+                );
+                reviewDTOs.add(reviewDTO);
+            }
+
+            return new StoreDetailDTO(
+                    store.getId(),
+                    store.getStoreId(),
+                    store.getBizplcNm(),
+                    store.getLicensgDe(),
+                    store.getBsnStateNm(),
+                    store.getClsbizDe(),
+                    store.getLocplcAr(),
+                    store.getGradFacltDivNm(),
+                    store.getMaleEnflpsnCnt(),
+                    store.getYy(),
+                    store.getMultiUseBizestblYn(),
+                    store.getGradDivNm(),
+                    store.getTotFacltScale(),
+                    store.getFemaleEnflpsnCnt(),
+                    store.getBsnsiteCircumfrDivNm(),
+                    store.getSanittnIndutypeNm(),
+                    store.getSanittnBizcondNm(),
+                    store.getTotEmplyCnt(),
+                    store.getRefineRoadnmAddr(),
+                    store.getRefineLotnoAddr(),
+                    store.getRefineZipCd(),
+                    store.getRefineWgs84Lat(),
+                    store.getRefineWgs84Logt(),
+                    store.getRating(),
+                    reviewDTOs
+            );
+        } else {
+            throw new EntityNotFoundException("Store를 찾을 수 없습니다.");
+        }
+    }
+
 }

--- a/demo/src/main/java/com/wanted/demo/store/service/StoreService.java
+++ b/demo/src/main/java/com/wanted/demo/store/service/StoreService.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 
 @Service
@@ -18,7 +19,7 @@ public class StoreService {
         this.storeRepository = storeRepository;
     }
 
-    public List<StoreListDTO> findStoresInRange(double lat, double lon, double range) {
+    public List<StoreListDTO> findStoresInRange(double lat, double lon, double range, String sort) {
         List<Store> stores = storeRepository.findAll();
 
         List<StoreListDTO> storesInRange = new ArrayList<>();
@@ -42,6 +43,18 @@ public class StoreService {
                 storesInRange.add(storeListDTO);
             }
         }
+
+        switch (sort) {
+            case "distance":
+                storesInRange.sort(Comparator.comparing(StoreListDTO::getDistance));
+                break;
+            case "rating":
+                storesInRange.sort(Comparator.comparing(StoreListDTO::getRating).reversed());
+                break;
+            default:
+                storesInRange.sort(Comparator.comparing(StoreListDTO::getDistance));
+        }
+
         return storesInRange;
     }
 

--- a/demo/src/main/java/com/wanted/demo/store/service/StoreService.java
+++ b/demo/src/main/java/com/wanted/demo/store/service/StoreService.java
@@ -46,7 +46,7 @@ public class StoreService {
     }
 
     private double latLonToKm(double storeLat, double storeLon, double lat2, double lon2) {
-        double radius = 6371; //km
+        double radius = 6371; //(km)
 
         double dLat = Math.toRadians(lat2 - storeLat);
         double dLon = Math.toRadians(lon2 - storeLon);


### PR DESCRIPTION
## 상세 내용
- 시군구 목록 (api)
- 추가 필드 관리 (평점 rating)
- 맛집 목록 (api)
  query | 속성 | default(미입력 시 값) | 설명
  -- | -- | -- | --
  lat | string | 필수값 | 지구 y축 원점 기준 거리
  lon | string | 필수값 | 주기 x축 원점 기준 거리
  range | double | 필수값 | km 를 소숫점으로 나타냅니다. 0.5 = 500m / 1.0 = 1000km
  정렬 | string | 거리순 | 정렬기능 파라메터 구조는 자유롭게 구현하되, 위에서 계산된 요청 좌표와 식당 사이의 거리인 거리순 과 평점순을 지원해야합니다.
  기타 |   |   |  

- 맛집 상세정보 (api)
  - 맛집 모든 필드와 평가 상세 리스트를 포함합니다.